### PR TITLE
Strip annotations from executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased changes
 
 ### New features
+- `ExportAnnotations` has a new `--no-export` option to skip the exporting phase entirely.
 
 ### Changes to existing features
 - Ownership of the project changed from @rdeago to @Tenacom.
 
 ### Bugs fixed in this release
 - [#3](https://github.com/tenacom/ReSharper.ExportAnnotations/issues/3) - ReSharper.ExportAnnotations.Task does not work with `dotnet build` and `dotnet msbuild`
+- [#6](https://github.com/tenacom/ReSharper.ExportAnnotations/issues/6) - Annotations are not stripped from executables
 
 ### Known problems introduced by this release
 

--- a/src/ExportAnnotations/Program.cs
+++ b/src/ExportAnnotations/Program.cs
@@ -26,6 +26,13 @@ namespace ExportAnnotations
         [UsedImplicitly]
         public string AssemblyPath { get; } = string.Empty;
 
+        [Option(
+            Description = "Do not export annotations (but strip them if --strip is specified)",
+            LongName = "no-export",
+            ShortName = "n")]
+        [UsedImplicitly]
+        public bool NoExport { get; }
+
         [Argument(1, "xmlPath", Description = "Full path of the generated XML file (defaults to a .ExternalAnnotations.xml file side by side with the assembly)")]
         [LegalFilePath]
         [UsedImplicitly]
@@ -62,6 +69,7 @@ namespace ExportAnnotations
                 : Array.Empty<string>();
 
             var parameters = new AnnotationsExporterParameters()
+                .WithExportAnnotations(!NoExport)
                 .WithXmlPath(XmlPath)
                 .WithLibraries((LibraryPaths ?? Enumerable.Empty<string>()).Concat(listedLibraries))
                 .WithStripAnnotations(Strip);

--- a/src/ReSharper.ExportAnnotations.Task/build/ReSharper.ExportAnnotations.Task.targets
+++ b/src/ReSharper.ExportAnnotations.Task/build/ReSharper.ExportAnnotations.Task.targets
@@ -44,7 +44,7 @@
 
   <!-- Run tool immediately after compiler -->
   <Target Name="_ExportAnnotations_RunTool"
-          Condition="$(ExportJetBrainsAnnotations) And ('$(SkipCompilerExecution)' != 'true')"
+          Condition="($(ExportJetBrainsAnnotations) Or $(StripJetBrainsAnnotations)) And ('$(SkipCompilerExecution)' != 'true')"
           AfterTargets="CoreCompile">
 
     <PropertyGroup>

--- a/src/ReSharper.ExportAnnotations.Task/build/ReSharper.ExportAnnotations.Task.targets
+++ b/src/ReSharper.ExportAnnotations.Task/build/ReSharper.ExportAnnotations.Task.targets
@@ -59,6 +59,7 @@
     <!-- Complete command line with options -->
     <PropertyGroup>
       <_ExportAnnotationsCommandLine>$(_ExportAnnotationsCommand) &quot;%(IntermediateAssembly.FullPath)&quot;</_ExportAnnotationsCommandLine>
+      <_ExportAnnotationsCommandLine Condition="!$(ExportJetBrainsAnnotations)">$(_ExportAnnotationsCommandLine) --no-export</_ExportAnnotationsCommandLine>
       <_ExportAnnotationsCommandLine Condition="$(StripJetBrainsAnnotations)">$(_ExportAnnotationsCommandLine) --strip</_ExportAnnotationsCommandLine>
       <_ExportAnnotationsCommandLine>$(_ExportAnnotationsCommandLine) --liblist &quot;$(_ExportAnnotationsLibraryList)&quot;</_ExportAnnotationsCommandLine>
     </PropertyGroup>


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [x] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Dependency update / new dependency
- [ ] Other (please describe below)

## Proposed changes / fixed issues

Closes #6

Also an enhancement, due to new option `--no-export` in ExportAnnotations.

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [x] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Tenacom/ReSharper.ExportAnnotations/blob/master/CHANGELOG.md) according to the modifications I made

## Other information
