### PR TITLE
Improve documentation for NuGet packages

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -9,6 +9,7 @@
     <Copyright>Copyright (c) 2018-2020 Riccardo De Agostini and Tenacom</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Tenacom/ReSharper.ExportAnnotations</PackageProjectUrl>
+    <MinClientVersion>4.3</MinClientVersion> <!-- Minimum NuGet client version supporting SemVer 2.0 -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 [![Open issues](https://img.shields.io/github/issues-raw/Tenacom/ReSharper.ExportAnnotations.svg?label=open+issues)](https://github.com/Tenacom/ReSharper.ExportAnnotations/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
 [![Closed issues](https://img.shields.io/github/issues-closed-raw/Tenacom/ReSharper.ExportAnnotations.svg?label=closed+issues)](https://github.com/Tenacom/ReSharper.ExportAnnotations/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc)
 
-Welcome to the ultimate solution for [ReSharper](https://www.jetbrains.com/resharper/) users who want to distribute [code annotations](https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html) along with their libraries, without the burden of [additional dependencies](https://www.nuget.org/packages/JetBrains.Annotations) or [extraneous code](https://www.jetbrains.com/help/resharper/Code_Analysis__Annotations_in_Source_Code.html#embedding-declarations-of-code-annotations-in-your-source-code) added to their projects!
+The ultimate, one-stop solution to distribute ReSharper<sup>[(*)](#jetbrains-disclaimer)</sup> code annotations in XML format along with your libraries.
 
-Enjoy ReSharper finally recognizing your `[NotNull]`, `[CanBeNull]`, `[ContractAnnotation]`, `[InstantHandle]`, and all other code annotations, without dragging transitive dependencies around, and without [redeclaring the same attributes](https://www.jetbrains.com/help/resharper/Code_Analysis__Annotations_in_Source_Code.html#embedding-declarations-of-code-annotations-in-your-source-code) over and over.
-
-*Disclaimer:* The author of this library is in no way affiliated to [JetBrains s.r.o.](https://www.jetbrains.com/) (the makers of ReSharper).
+Enjoy ReSharper recognizing your code annotations when working on dependent projects, without dragging transitive dependencies around, and without [redeclaring the same attributes](https://www.jetbrains.com/help/resharper/Code_Analysis__Annotations_in_Source_Code.html#embedding-declarations-of-code-annotations-in-your-source-code) over and over.
 
 ---
 
@@ -138,3 +136,7 @@ You may disable this check by setting the `CheckForJetBrainsAnnotationsPackageRe
 The font used in the package icon is [Inconsolata Bold](https://fontlibrary.org/en/font/inconsolata#Inconsolata-Bold) by Raph Levien, Kirill Tkachev (cyreal.org), from [Font Library](https://fontlibrary.org).
 
 The font used in the logo is [BloggerSans.otf](https://fontlibrary.org/en/font/blogger-sans-otf) by Sergiy S. Tkachenko, from [Font Library](https://fontlibrary.org).
+
+---
+
+<a name="jetbrains-disclaimer">(*)</a> [ReSharper](https://www.jetbrains.com/resharper) is a product of [JetBrains s.r.o.](https://www.jetbrains.com). The authors and owners of this project are not affiliated with JetBrains in any way. The use of the ReSharper name does not imply endorsement of this project by JetBrains.

--- a/src/ReSharper.ExportAnnotations.Core/NuGet-README.md
+++ b/src/ReSharper.ExportAnnotations.Core/NuGet-README.md
@@ -1,0 +1,7 @@
+A library to export ReSharper code annotations from compiled assemblies in XML format.
+
+Unless you specifically need this library, you are probably looking for [`ReSharper.ExportAnnotations.Task`](https://www.nuget.org/packages/ReSharper.ExportAnnotations.Task), the ultimate, one-stop solution to distribute code annotations in XML format along with your libraries.
+
+---
+
+[ReSharper](https://www.jetbrains.com/resharper) is a product of [JetBrains s.r.o.](https://www.jetbrains.com). The authors and owners of this package are not affiliated with JetBrains in any way. The use of the ReSharper name does not imply endorsement of this package by JetBrains.

--- a/src/ReSharper.ExportAnnotations.Core/NuGet-README.md
+++ b/src/ReSharper.ExportAnnotations.Core/NuGet-README.md
@@ -1,4 +1,4 @@
-A library to export ReSharper code annotations from compiled assemblies in XML format.
+A library to export ReSharper code annotations in XML format from compiled assemblies.
 
 Unless you specifically need this library, you are probably looking for [`ReSharper.ExportAnnotations.Task`](https://www.nuget.org/packages/ReSharper.ExportAnnotations.Task), the ultimate, one-stop solution to distribute code annotations in XML format along with your libraries.
 

--- a/src/ReSharper.ExportAnnotations.Core/ReSharper.ExportAnnotations.Core.csproj
+++ b/src/ReSharper.ExportAnnotations.Core/ReSharper.ExportAnnotations.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>ReSharper.ExportAnnotations</RootNamespace>
-    <Description>Utility library to export JetBrains annotations (and optionally strip them) from a compiled assembly.</Description>
+    <Description>A library to export ReSharper code annotations in XML format from compiled assemblies.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/ReSharper.ExportAnnotations.Core/ReSharper.ExportAnnotations.Core.csproj
+++ b/src/ReSharper.ExportAnnotations.Core/ReSharper.ExportAnnotations.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>ReSharper.ExportAnnotations</RootNamespace>
     <Description>A library to export ReSharper code annotations in XML format from compiled assemblies.</Description>
+    <PackageTags>jetbrains resharper annotations xml</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/ReSharper.ExportAnnotations.Task/NuGet-README.md
+++ b/src/ReSharper.ExportAnnotations.Task/NuGet-README.md
@@ -1,0 +1,17 @@
+# ![ReSharper.ExportAnnotations](https://raw.githubusercontent.com/Tenacom/ReSharper.ExportAnnotations/main/graphics/Logo.png)
+
+The ultimate, one-stop solution to distribute ReSharper code annotations in XML format along with your libraries.
+
+No transitive dependencies. No added code.
+
+---
+
+- [Quick start](https://github.com/tenacom/ReSharper.ExportAnnotations/blob/main/README.md#quick-start)
+- [How it works](https://github.com/tenacom/ReSharper.ExportAnnotations/blob/main/README.md#how-it-works)
+- [FAQ](https://github.com/tenacom/ReSharper.ExportAnnotations/blob/main/README.md#faq)
+- [Configuration](https://github.com/tenacom/ReSharper.ExportAnnotations/blob/main/README.md#configuration)
+- [Credits](https://github.com/tenacom/ReSharper.ExportAnnotations/blob/main/README.md#credits)
+
+---
+
+[ReSharper](https://www.jetbrains.com/resharper) is a product of [JetBrains s.r.o.](https://www.jetbrains.com). The authors and owners of this package are not affiliated with JetBrains in any way. The use of the ReSharper name does not imply endorsement of this package by JetBrains.

--- a/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
+++ b/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
@@ -12,7 +12,7 @@
     <IsPackable>true</IsPackable>
     <IncludeSymbols>false</IncludeSymbols>
     <Summary>Helps you distribute a .ExternalAnnotations.xml file instead of creating a dependency on JetBrains.Annotations.</Summary>
-    <Description>Documentation is available here: $(RepositoryUrl)/blob/master/README.md</Description>
+    <Description>The ultimate, one-stop solution to distribute ReSharper code annotations in XML format along with your libraries.</Description>
     <PackageTags>build msbuild jetbrains resharper annotations</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Serviceable>true</Serviceable>

--- a/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
+++ b/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
@@ -15,7 +15,6 @@
     <PackageTags>build msbuild jetbrains resharper annotations</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Serviceable>true</Serviceable>
-    <MinClientVersion>4.3</MinClientVersion> <!-- Minimum NuGet client version supporting SemVer 2.0 -->
 
     <!-- Prevent the SDK from adding an actual ProjectReference item for ExportAnnotations.
          The dependency on ExportAnnotations is set in the solution file.

--- a/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
+++ b/src/ReSharper.ExportAnnotations.Task/ReSharper.ExportAnnotations.Task.csproj
@@ -11,7 +11,6 @@
     <!-- Package metadata -->
     <IsPackable>true</IsPackable>
     <IncludeSymbols>false</IncludeSymbols>
-    <Summary>Helps you distribute a .ExternalAnnotations.xml file instead of creating a dependency on JetBrains.Annotations.</Summary>
     <Description>The ultimate, one-stop solution to distribute ReSharper code annotations in XML format along with your libraries.</Description>
     <PackageTags>build msbuild jetbrains resharper annotations</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation update
- [ ] Dependency update / new dependency
- [ ] Other (please describe below)

## Proposed changes / fixed issues

- Improve wording of README iontroduction.
- Improve wording of disclaimer.
- Add shorter README files specific for each package.
- Standardize wording between package description and README for each packable project.
- Remove unused Summary property in `ReSharper.ExportAnnotations.Task.csproj`.
- Add package tags for `ReSharper.ExportAnnotations.Core`.
- Move the `MinClientVersion` property to `Common.props` so it gets taken up by all packable projects.

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [x] I have added and/or updated related documentation (if applicable)
- [ ] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Tenacom/ReSharper.ExportAnnotations/blob/master/CHANGELOG.md) according to the modifications I made

## Other information
